### PR TITLE
 Refactor of UDPController into a Service

### DIFF
--- a/components/udpcontroller/CMakeLists.txt
+++ b/components/udpcontroller/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(COMPONENT_ADD_INCLUDEDIRS include)
-set(COMPONENT_SRCS  "udpcontroller.cpp")
+set(COMPONENT_SRCS  "udpservice.cpp")
 
-set(COMPONENT_REQUIRES 
+set(COMPONENT_REQUIRES
         freertos
-        log
         lwip
     )
 

--- a/components/udpcontroller/include/udpservice.hpp
+++ b/components/udpcontroller/include/udpservice.hpp
@@ -46,8 +46,8 @@ namespace communication
      *   TickType_t xDelay = pdMS_TO_TICKS( 500 );
      *   for(;;)
      *   {
-     *     udpController->process_next_message();
-     *     udpController->listen();
+     *     udpService->process_next_message();
+     *     udpService->listen();
      *     vTaskDelay(xDelay);
      *   }
      * }

--- a/components/udpcontroller/include/udpservice.hpp
+++ b/components/udpcontroller/include/udpservice.hpp
@@ -10,14 +10,14 @@
 
 #include <list>
 
-#include "udpcontroller_incoming_message_handler.hpp"
+#include "udpservicemessagehandler.hpp"
 
-#ifndef UDPCONTROLLER_QUEUE_SIZE
-#define UDPCONTROLLER_QUEUE_SIZE 5
+#ifndef UDPSERVICE_QUEUE_SIZE
+#define UDPSERVICE_QUEUE_SIZE 5
 #endif
 
-#ifndef UDPCONTROLLER_PORT
-#define UDPCONTROLLER_PORT 6000
+#ifndef UDPSERVICE_PORT
+#define UDPSERVICE_PORT 6000
 #endif
 
 
@@ -39,21 +39,43 @@ namespace communication
 
     /**
      * @brief UdpController sending and receiving messages via broadcasting
+     * e.g. via:
+     * <code>
+     * void controller_task( void* pvParameter )
+     * {
+     *   TickType_t xDelay = pdMS_TO_TICKS( 500 );
+     *   for(;;)
+     *   {
+     *     udpController->process_next_message();
+     *     udpController->listen();
+     *     vTaskDelay(xDelay);
+     *   }
+     * }
+     * </code>
      */
-    class Controller
+
+    class Service
     {
     public:
-      Controller();
+      Service();
+      ~Service();
 
       /*
        * Enqueues a message on the send buffer
        */
-      BaseType_t enqueue_message(uint8_t *, size_t);
+      BaseType_t enqueue(uint8_t *, size_t);
 
       /*
-       * Sets the UDP port used for communication
+       * Returns the current UDP Port
        */
-      Controller* set_udpport(uint16_t);
+      uint16_t udpport();
+
+      /*
+       * Sets the UDP port used for communication.
+       * Registered Ports only (see IANA Allocation Guidelines for TCP and UDP Port Numbers).
+       * If invalid port is used, then UDPSERVICE_PORT is used.
+       */
+      void udpport(uint16_t);
 
       /*
        * Starts the Controller. This function creates a socket
@@ -61,50 +83,43 @@ namespace communication
        * If all goes well, it sets running_ to true.
        */
       void start();
-      
+
       /**
        * Stops the controller. It closes and removes the socket.
        */
       void stop();
 
       /**
-       * A single loop of the Controller. It should be embedded in a FreeRTOS Task, 
-       * e.g. via:
-       * <code>
-       * void controller_task( void* pvParameter )
-       * {
-       *   TickType_t xDelay = pdMS_TO_TICKS( 500 );
-           for(;;)
-           {
-             udpController->work_loop();    
-             vTaskDelay(xDelay);
-           }
-         }
-       * </code>
+       * Returns whether the service is started
        */
-      void work_loop();
+      bool is_running();
+
+       /**
+       * Takes the first element of the queue en sends it via UDP
+       */
+      void process_next_message();
+
+      /**
+       * Tries to read a single message from the socket
+       */
+      void listen();
 
       /**
        * Adds a message handler to the controller to see if there are any
        * incoming messages
        */
-      void register_handler(MessageHandler*);
+      void add(MessageHandler*);
 
       /**
        * Removes a handler
        */
-      void unregister_handler(MessageHandler*);
+      void remove(MessageHandler*);
 
     private:
       /**
        * The internal queue used for sending messages
        */
       QueueHandle_t xQueue_;
-
-      /**
-       * The port number used for UDP traffic
-       */
-      uint16_t udpport_ = UDPCONTROLLER_PORT;
 
       /**
        * The socket
@@ -117,10 +132,16 @@ namespace communication
        *   running === (socket_ > 0)
        */
       bool running_ = false;
+
+      /**
+       * Default address for broadcasting.
+       */
+      sockaddr_in broadcast_address_ = {};
+
       /**
        * Function to return the broadcast address
        */
-      sockaddr_in get_broadcast_address();
+      sockaddr_in broadcast_address();
 
       /**
        * Create a new socket that can be used for broadcasting
@@ -129,20 +150,10 @@ namespace communication
       int create_socket();
 
       /**
-       * List of all Listeners for the observer pattern
+       * List of all Handlers for the observer pattern
        */
-      std::list<MessageHandler*> listeners_;
+      std::list<MessageHandler*> handlers_;
 
-      /**
-       * Takes the first element of the queue en sends it via UDP
-       */
-      void process_next_message();
-
-      /**
-       * Tries to read a single message from the socket
-       */
-      void listen();
-      
       /**
        * Notifies all listeners if a message is sent.
        * It gives each listener its own copy of the message,

--- a/components/udpcontroller/include/udpservicemessagehandler.hpp
+++ b/components/udpcontroller/include/udpservicemessagehandler.hpp
@@ -9,9 +9,9 @@ namespace communication
     class MessageHandler
     {
     public:
-      virtual void on_message_received(uint8_t*, size_t);
+      virtual void on_message_received(uint8_t*, size_t)=0;
     };
-    
+
   } // End of namespace udp
 } // End of namespace communication
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,7 @@
-set(COMPONENT_SRCS 
+set(COMPONENT_SRCS
     "main.cpp"
     "wifiswitcher.cpp"
+    "udpserver.cpp"
 )
 
 set(COMPONENT_ADD_INCLUDEDIRS "")

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -13,6 +13,10 @@
 
 #include "wifiswitcher.hpp"
 
+#include "udpserver.hpp"
+
+UDPServer* udpServer = new UDPServer(6000);
+
 extern "C" {
 
     static esp_err_t handle_event(void *ctx, system_event_t *event)
@@ -23,7 +27,7 @@ extern "C" {
     void app_main()
     {
         esp_err_t ret = nvs_flash_init();
-        if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) 
+        if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND)
         {
             ESP_ERROR_CHECK(nvs_flash_erase());
             ret = nvs_flash_init();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -19,6 +19,12 @@ UDPServer* udpServer = new UDPServer(6000);
 
 extern "C" {
 
+    void udpservertask(void* pvParameters )
+    {
+      udpServer->task(pvParameters);
+    }
+
+
     static esp_err_t handle_event(void *ctx, system_event_t *event)
     {
         return EventHandlers::handle_event(ctx, event);
@@ -44,5 +50,8 @@ extern "C" {
         WifiSwitcher::station()->set_password("defaultPassword");
 
         WifiSwitcher::start();
+
+        // Run the UDPServer task on priority 2
+        xTaskCreate(udpservertask, "UDP Server on port 6000", 8000, NULL, 2, NULL);
     }
 }

--- a/main/udpserver.cpp
+++ b/main/udpserver.cpp
@@ -1,9 +1,11 @@
 #include "udpserver.hpp"
 #include "esp_log.h"
+#include "event_handlers.hpp"
 
 UDPServer::UDPServer()
 {
 	service_ = new communication::udp::Service();
+	EventHandlers::add(this);
 }
 
 UDPServer::UDPServer(uint16_t portnumber) : UDPServer()

--- a/main/udpserver.cpp
+++ b/main/udpserver.cpp
@@ -1,0 +1,76 @@
+#include "udpserver.hpp"
+#include "esp_log.h"
+
+UDPServer::UDPServer()
+{
+	service_ = new communication::udp::Service();
+}
+
+UDPServer::UDPServer(uint16_t portnumber) : UDPServer()
+{
+	port(portnumber);
+}
+
+UDPServer::~UDPServer()
+{
+	stop();
+}
+
+uint16_t UDPServer::port()
+{
+	return service_->udpport();
+}
+
+void UDPServer::port(uint16_t portnumber)
+{
+	service_->udpport(portnumber);
+}
+
+void UDPServer::start()
+{
+	service_->start();
+}
+
+void UDPServer::stop()
+{
+	service_->stop();
+}
+
+communication::udp::Service* UDPServer::service()
+{
+	return service_;
+}
+
+esp_err_t UDPServer::handle_event(void *ctx, system_event_t *event)
+{
+	switch(event->event_id)
+	{
+		case SYSTEM_EVENT_STA_GOT_IP:
+			start();
+			break;
+		case SYSTEM_EVENT_STA_DISCONNECTED:
+			stop();
+			break;
+		default:
+			break;
+	}
+	return ESP_OK;
+}
+
+void UDPServer::on_message_received(uint8_t *data, size_t length)
+{
+	(void) data;
+	ESP_LOGI("UDPServer", "I received a message of size: %d", length);
+}
+
+void UDPServer::task(void* pvParameter)
+{
+	TickType_t xDelay = pdMS_TO_TICKS( 500 );
+
+	for(;;)
+	{
+		service_->process_next_message();
+    service_->listen();
+    vTaskDelay(xDelay);
+	}
+}

--- a/main/udpserver.hpp
+++ b/main/udpserver.hpp
@@ -1,0 +1,39 @@
+#ifndef UDPSERVER_HPP_
+#define UDPSERVER_HPP_
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+
+#include "udpservice.hpp"
+#include "udpservicemessagehandler.hpp"
+#include "event_handler.hpp"
+
+class UDPServer : public EventHandler, public communication::udp::MessageHandler
+{
+public:
+	UDPServer();
+	UDPServer(uint16_t port);
+
+	~UDPServer();
+
+	uint16_t port();
+	void port(uint16_t);
+
+	void start();
+	void stop();
+
+	esp_err_t handle_event(void *, system_event_t*);
+	void on_message_received(uint8_t*, size_t);
+
+	void task(void* pvParameter);
+
+
+	communication::udp::Service* service();
+
+private:
+	communication::udp::Service* service_;
+};
+
+
+#endif


### PR DESCRIPTION
This UDP Service is a UDP-broadcast based communication service. 

- Us a configurable UDP Port based on the IANA guidelines, i.e., only registered ports (between 1024 and 49151) are allowed.
- Components can ```enqueue``` a message. The service will then try to send it over the specified UDP port. 
- listen() tries to listen for a single message on the UDP port. It is a non-blocking function.
- process_next_message() sends the first message in the send queue
- Handlers can be added and removed to listen for incoming messages. For security, each handler gets its own copy of the message.

A sample server with task and logic to respond to WIFI connection changes is implemented in ```udpserver.cpp``` in the main component.